### PR TITLE
Major rework of how handleRequest actually works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,8 @@ require (
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/biessek/golang-ico v0.0.0-20180326222316-d348d9ea4670
 	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
-	github.com/fatih/structs v1.0.0
 	github.com/ghetzel/cli v1.17.0
-	github.com/ghetzel/go-stockutil v1.8.4
+	github.com/ghetzel/go-stockutil v1.8.15
 	github.com/ghetzel/go-webfriend v0.9.60
 	github.com/ghetzel/testify v1.4.1
 	github.com/ghodss/yaml v1.0.0
@@ -15,7 +14,6 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/grokify/html-strip-tags-go v0.0.0-20180530080503-3f8856873ce5
-	github.com/h2non/filetype v1.0.8
 	github.com/husobee/vestigo v1.1.0
 	github.com/jbenet/go-base58 v0.0.0-20150317085156-6237cf65f3a6
 	github.com/kelvins/sunrisesunset v0.0.0-20170601204625-14f1915ad4b4
@@ -28,7 +26,7 @@ require (
 	github.com/signalsciences/tlstext v1.2.0
 	github.com/spaolacci/murmur3 v0.0.0-20170819071325-9f5d223c6079
 	github.com/tg123/go-htpasswd v0.0.0-20190305225429-d38e564730bf
-	github.com/urfave/negroni v1.0.0
+	github.com/urfave/negroni v1.0.1-0.20191011213438-f4316798d5d3
 	github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8
 	github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/ghetzel/go-stockutil v1.8.3 h1:iJpfCNXsp91GWkl0qOzHEUHMUQOvr/Gz9yhGdQ
 github.com/ghetzel/go-stockutil v1.8.3/go.mod h1:zHk/p1VcoQbWngvmelsQbFbZ6eIQDA4D3ryZPYLoZ1I=
 github.com/ghetzel/go-stockutil v1.8.4 h1:6j2iYVciDnCgfEmllWq2zbf7MkzUoN0b6jJu5POVqj0=
 github.com/ghetzel/go-stockutil v1.8.4/go.mod h1:tq1ycYqlC1z9ZX/Pvgz+sePJvpHsJbd692w8936ed+U=
+github.com/ghetzel/go-stockutil v1.8.15 h1:EiRjJYIjH7G7XYaBxYaAcP7VgbHCeMSAQrIeahwgBlQ=
+github.com/ghetzel/go-stockutil v1.8.15/go.mod h1:b7mmPNCNKPkZIiK0eexQUwhUeCy72KOJK14k4NaJb5g=
 github.com/ghetzel/go-webfriend v0.9.23/go.mod h1:4tjKFGdCtac9eXJ8Hz48DSCoiwjhzynwFFiyhsLfMnI=
 github.com/ghetzel/go-webfriend v0.9.40 h1:yTK+owpwiOycRSaZWzxWoQE3cDO/BX83mpvFPs9/bJ4=
 github.com/ghetzel/go-webfriend v0.9.40/go.mod h1:RDBxcAknpDWMJFOKS9AFiNldv+R6siUKFB4DDv+BGRI=
@@ -264,6 +266,8 @@ github.com/tg123/go-htpasswd v0.0.0-20190305225429-d38e564730bf/go.mod h1:rFFqmv
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/negroni v1.0.0 h1:kIimOitoypq34K7TG7DUaJ9kq/N4Ofuwi1sjz0KipXc=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+github.com/urfave/negroni v1.0.1-0.20191011213438-f4316798d5d3 h1:FD+MOA0pvj+qGO5KNyBKwuNjx992SwMMb000oi4co9U=
+github.com/urfave/negroni v1.0.1-0.20191011213438-f4316798d5d3/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8 h1:OlIHDBRrlQk8fHa662oG2gzOO/ixBRU9sLht/M9kzK0=
 github.com/yosssi/gohtml v0.0.0-20180130040904-97fbf36f4aa8/go.mod h1:+ccdNT0xMY1dtc5XBxumbYfOUhmduiGudqaDgD2rVRE=

--- a/mount.go
+++ b/mount.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"path/filepath"
+	"strings"
 
 	"github.com/ghetzel/go-stockutil/log"
 	"github.com/ghetzel/go-stockutil/stringutil"
@@ -59,6 +60,15 @@ func NewMountFromSpec(spec string) (Mount, error) {
 	}
 
 	return mount, nil
+}
+
+func mountSummary(mount Mount) string {
+	mtype := fmt.Sprintf("%T", mount)
+	mtype = strings.TrimPrefix(mtype, `*diecast.`)
+	mtype = strings.TrimSuffix(mtype, `Mount`)
+	mtype = strings.ToLower(mtype)
+
+	return fmt.Sprintf("%s: %s -> %s", mtype, mount.GetMountPoint(), mount.GetTarget())
 }
 
 func IsSameMount(first Mount, second Mount) bool {

--- a/renderers_template.go
+++ b/renderers_template.go
@@ -78,7 +78,7 @@ func (self *TemplateRenderer) Render(w http.ResponseWriter, req *http.Request, o
 
 		// this entire if-block is just for debugging templates
 		if self.server.ShouldReturnSource(req) {
-			w.Header().Set(`Content-Type`, `text/plain`)
+			w.Header().Set(`Content-Type`, `text/plain; charset=utf-8`)
 
 			if fn := self.prewrite; fn != nil {
 				fn(req)

--- a/server_handler.go
+++ b/server_handler.go
@@ -1,0 +1,349 @@
+package diecast
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/ghetzel/go-stockutil/fileutil"
+	"github.com/ghetzel/go-stockutil/httputil"
+	"github.com/ghetzel/go-stockutil/log"
+	"github.com/ghetzel/go-stockutil/sliceutil"
+)
+
+type candidateFile struct {
+	Type          string
+	Source        string
+	Path          string
+	Data          http.File
+	StatusCode    int
+	MimeType      string
+	RedirectTo    string
+	RedirectCode  int
+	Headers       map[string]interface{}
+	PathParams    map[string]interface{}
+	ForceTemplate bool
+}
+
+// The main entry point for handling requests not otherwise intercepted by Actions or User Routes.
+//
+// The Process:
+//     1. Build a list of paths to try based on the requested path.  This is how things like
+//        expanding "/thing" -> "/thing/index.html" OR "/thing.html" works.
+//
+//     2. For each path, do the following:
+//
+//        a. try to find a local file named X in the webroot
+//        b.
+//
+func (self *Server) handleRequest(w http.ResponseWriter, req *http.Request) {
+	id := reqid(req)
+	prefix := fmt.Sprintf("%s/", self.rp())
+
+	var lastErr error
+	var serveFile *candidateFile
+
+	if strings.HasPrefix(req.URL.Path, prefix) {
+		defer req.Body.Close()
+
+		// get a sequence of paths to search
+		requestPaths := self.candidatePathsForRequest(req)
+
+		var localCandidate *candidateFile
+		var mountCandidate *candidateFile
+		var autoindexCandidate *candidateFile
+
+		// SEARCH PHASE: locate a pile of data to serve and possibly templatize
+		// -----------------------------------------------------------------------------------------
+
+		// search for local files and autoindex opportunities
+		for _, rPath := range requestPaths {
+			log.Debugf("[%s] try local file: %s", id, rPath)
+
+			// actually try to stat the file from the filesystem rooted at RootPath
+			if file, mimetype, err := self.tryLocalFile(rPath, req); err == nil {
+				if localCandidate == nil {
+					log.Debugf("[%s] found local file: %s", id, rPath)
+					localCandidate = &candidateFile{
+						Type:     `local`,
+						Source:   httpFilename(file),
+						Path:     rPath,
+						Data:     file,
+						MimeType: mimetype,
+					}
+				} else {
+					break
+				}
+			} else if IsDirectoryErr(err) && self.Autoindex {
+				if file, mimetype, ok := self.tryAutoindex(); ok {
+					if autoindexCandidate == nil {
+						log.Debugf("[%s] found autoindex template for %s", id, rPath)
+						autoindexCandidate = &candidateFile{
+							Type:          `autoindex`,
+							Source:        httpFilename(file),
+							Path:          rPath,
+							Data:          file,
+							MimeType:      mimetype,
+							ForceTemplate: true,
+						}
+					}
+				}
+			}
+		}
+
+		// if we're not interested in local files first (therefore, we need to try the mounts anyway), or
+		// we ARE trying local first, but nothing came back, then try searching mounts
+		if !self.TryLocalFirst || localCandidate == nil {
+			for _, rPath := range requestPaths {
+				if mount, mountResponse, err := self.tryMounts(rPath, req); err == nil && mountResponse != nil {
+					if mountCandidate == nil {
+						log.Debugf("[%s] found mount response: %s", id, rPath)
+						mountCandidate = &candidateFile{
+							Type:         `mount`,
+							Source:       mountSummary(mount),
+							Path:         rPath,
+							Data:         mountResponse.GetFile(),
+							MimeType:     mountResponse.ContentType,
+							StatusCode:   mountResponse.StatusCode,
+							Headers:      mountResponse.Metadata,
+							RedirectTo:   mountResponse.RedirectTo,
+							RedirectCode: mountResponse.RedirectCode,
+						}
+					} else {
+						break
+					}
+
+				} else if IsHardStop(err) {
+					// A mount Hard Stop means:
+					//  1. a mount handled the thing
+					//  2. that mount explicitly wants us to return an error
+					//  3. it doesn't matter if there are other candidate files, Hard Stop wins
+					lastErr = err
+					break
+				}
+			}
+		}
+
+		if localCandidate != nil {
+			defer localCandidate.Data.Close()
+		}
+
+		if mountCandidate != nil {
+			defer mountCandidate.Data.Close()
+		}
+
+		if autoindexCandidate != nil {
+			defer autoindexCandidate.Data.Close()
+		}
+
+		if lastErr == nil {
+			if self.TryLocalFirst {
+				if localCandidate != nil {
+					serveFile = localCandidate
+				} else if mountCandidate != nil {
+					serveFile = mountCandidate
+				} else if autoindexCandidate != nil {
+					serveFile = autoindexCandidate
+				}
+			} else {
+				if mountCandidate != nil {
+					serveFile = mountCandidate
+				} else if localCandidate != nil {
+					serveFile = localCandidate
+				} else if autoindexCandidate != nil {
+					serveFile = autoindexCandidate
+				}
+			}
+
+			if serveFile != nil {
+				log.Debugf("[%s] found: %s (%v)", id, serveFile.Type, serveFile.Source)
+
+				serveFile.PathParams = make(map[string]interface{})
+
+				// TODO: better support for url parameters in filenames
+				// filename := filepath.Base(rPath)
+				// filename = strings.TrimSuffix(filename, filepath.Ext(filepath))
+				// basepath := strings.Trim(path.Base(req.URL.Path), `/`)
+
+				// for i, part := range strings.Split(filename, `__`) {
+
+				// 	urlParams[typeutil.String(i)] =
+				// 	urlParams[part] =
+				// }
+
+				if strings.Contains(serveFile.Path, `__id.`) {
+					serveFile.PathParams[`1`] = strings.Trim(path.Base(req.URL.Path), `/`)
+					serveFile.PathParams[`id`] = strings.Trim(path.Base(req.URL.Path), `/`)
+				}
+
+				if rcode := serveFile.RedirectCode; rcode > 0 {
+					if serveFile.RedirectTo == `` {
+						serveFile.RedirectTo = fmt.Sprintf("%s/", req.URL.Path)
+					}
+
+					http.Redirect(w, req, serveFile.RedirectTo, rcode)
+					log.Debugf("[%s] path %v redirecting to %v (HTTP %d)", id, serveFile.Path, serveFile.RedirectTo, rcode)
+					return
+				} else if handled := self.handleCandidateFile(w, req, serveFile); handled {
+					return
+				}
+			}
+		}
+	}
+
+	if self.hasUserRoutes {
+		self.userRouter.ServeHTTP(w, req)
+	} else if lastErr != nil {
+		// something else went sideways
+		self.respondError(w, req, fmt.Errorf("[%s] an error occurred accessing %s: %v", id, req.URL.Path, lastErr), http.StatusServiceUnavailable)
+	} else {
+		// if we got *here*, then File Not Found
+		self.respondError(w, req, fmt.Errorf("[%s] File %q was not found.", id, req.URL.Path), http.StatusNotFound)
+	}
+}
+
+func (self *Server) candidatePathsForRequest(req *http.Request) []string {
+	requestPaths := []string{
+		req.URL.Path,
+	}
+
+	// if we're looking at a directory, throw in the index file if the path as given doesn't respond
+	if strings.HasSuffix(req.URL.Path, `/`) {
+		requestPaths = append(requestPaths, path.Join(req.URL.Path, self.IndexFile))
+
+		for _, ext := range self.TryExtensions {
+			base := filepath.Base(self.IndexFile)
+			base = strings.TrimSuffix(base, filepath.Ext(self.IndexFile))
+
+			requestPaths = append(requestPaths, path.Join(req.URL.Path, fmt.Sprintf("%s.%s", base, ext)))
+		}
+
+		for _, ext := range self.TryExtensions {
+			requestPaths = append(requestPaths, strings.TrimSuffix(req.URL.Path, `/`)+`.`+ext)
+		}
+
+	} else if path.Ext(req.URL.Path) == `` {
+		// if we're requesting a path without a file extension, try an index file in a directory with that name,
+		// then try just <filename>.html
+		requestPaths = append(requestPaths, fmt.Sprintf("%s/%s", req.URL.Path, self.IndexFile))
+
+		for _, ext := range self.TryExtensions {
+			requestPaths = append(requestPaths, fmt.Sprintf("%s.%s", req.URL.Path, ext))
+		}
+	}
+
+	// finally, add handlers for implementing routing
+	if parent := path.Dir(req.URL.Path); parent != `.` {
+		for _, ext := range self.TryExtensions {
+			requestPaths = append(requestPaths, fmt.Sprintf("%s/index__id.%s", strings.TrimSuffix(parent, `/`), ext))
+
+			if base := strings.TrimSuffix(parent, `/`); base != `` {
+				requestPaths = append(requestPaths, fmt.Sprintf("%s__id.%s", base, ext))
+			}
+		}
+	}
+
+	// unique the request paths
+	requestPaths = sliceutil.UniqueStrings(requestPaths)
+
+	// trim RoutePrefix from the front of all paths
+	for i, rPath := range requestPaths {
+		requestPaths[i] = strings.TrimPrefix(rPath, self.rp())
+	}
+
+	return requestPaths
+}
+
+func (self *Server) handleCandidateFile(
+	w http.ResponseWriter,
+	req *http.Request,
+	file *candidateFile,
+) bool {
+	if file == nil {
+		return false
+	}
+
+	// add in any metadata as response headers
+	for k, v := range file.Headers {
+		w.Header().Set(k, fmt.Sprintf("%v", v))
+	}
+
+	if file.MimeType == `` {
+		file.MimeType = fileutil.GetMimeType(file.Path, `application/octet-stream`)
+	}
+
+	// set Content-Type
+	w.Header().Set(`Content-Type`, file.MimeType)
+
+	// write out the HTTP status if we were given one
+	if file.StatusCode > 0 {
+		w.WriteHeader(file.StatusCode)
+	}
+
+	// we got a real actual file here, figure out if we're templating it or not
+	if self.shouldApplyTemplate(file.Path) || file.ForceTemplate {
+		// tease the template header out of the file
+		if header, templateData, err := SplitTemplateHeaderContent(file.Data); err == nil {
+			if header != nil {
+				if redirect := header.Redirect; redirect != nil {
+					w.Header().Set(`Location`, redirect.URL)
+
+					if redirect.Code > 0 {
+						w.WriteHeader(redirect.Code)
+					} else {
+						w.WriteHeader(http.StatusMovedPermanently)
+					}
+
+					return true
+				}
+			}
+
+			// render the final template and write it out
+			if err := self.applyTemplate(
+				w,
+				req,
+				file.Path,
+				templateData,
+				header,
+				file.PathParams,
+				file.MimeType,
+			); err != nil {
+				self.respondError(w, req, fmt.Errorf("render template: %v", err), http.StatusInternalServerError)
+			}
+		} else {
+			self.respondError(w, req, fmt.Errorf("parse template: %v", err), http.StatusInternalServerError)
+		}
+	} else {
+		// if not templated, then the file is returned outright
+		if rendererName := httputil.Q(req, `renderer`); rendererName == `` {
+			io.Copy(w, file.Data)
+		} else if renderer, err := GetRenderer(rendererName, self); err == nil {
+			if err := renderer.Render(w, req, RenderOptions{
+				Input: file.Data,
+			}); err != nil {
+				self.respondError(w, req, err, http.StatusInternalServerError)
+			}
+		} else if renderer, ok := GetRendererForFilename(file.Path, self); ok {
+			if err := renderer.Render(w, req, RenderOptions{
+				Input: file.Data,
+			}); err != nil {
+				self.respondError(w, req, err, http.StatusInternalServerError)
+			}
+		} else {
+			self.respondError(w, req, fmt.Errorf("Unknown renderer %q", rendererName), http.StatusBadRequest)
+		}
+	}
+
+	return true
+}
+
+func httpFilename(file http.File) string {
+	if stat, err := file.Stat(); err == nil {
+		return stat.Name()
+	}
+
+	return `<unknown>`
+}

--- a/timing.go
+++ b/timing.go
@@ -15,17 +15,19 @@ var reqTimes sync.Map
 var timerDescriptions sync.Map
 
 type requestTimer struct {
-	ID      string
-	Request *http.Request
-	Times   map[string]time.Duration
+	ID        string
+	Request   *http.Request
+	StartedAt time.Time
+	Times     map[string]time.Duration
 }
 
 func startRequestTimer(req *http.Request) {
 	if id := reqid(req); id != `` {
 		reqTimes.Store(id, &requestTimer{
-			ID:      id,
-			Request: req,
-			Times:   make(map[string]time.Duration),
+			ID:        id,
+			Request:   req,
+			StartedAt: time.Now(),
+			Times:     make(map[string]time.Duration),
 		})
 	}
 }
@@ -43,6 +45,18 @@ func reqtime(req *http.Request, key string, took time.Duration) {
 			}
 		}
 	}
+}
+
+func getRequestTimer(req *http.Request) *requestTimer {
+	if id := reqid(req); id != `` {
+		if v, ok := reqTimes.Load(id); ok {
+			if timer, ok := v.(*requestTimer); ok {
+				return timer
+			}
+		}
+	}
+
+	return nil
 }
 
 func writeRequestTimerHeaders(server *Server, w http.ResponseWriter, req *http.Request) {

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@ package diecast
 
 const ApplicationName = `diecast`
 const ApplicationSummary = `a standalone site templating engine that consumes REST services and renders static HTML output in realtime`
-const ApplicationVersion = `1.14.6`
+const ApplicationVersion = `1.15.0`


### PR DESCRIPTION
- Better handling of `AllowInsecureLoopbackBindings` that actually verifies that the request hostname IS a loopback address.
- Set `AllowInsecureLoopbackBindings` default true
- Improved MIME type detection for all served files
- More flexible Timeout specification for ProxyMount
- Organized and cleaned up logging
- Added overridable default that sets `Connection: close` on all responses unless disabled
