### PR TITLE
Adding option to perform transparent CSRF form field injection on served content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ require (
 	github.com/PuerkitoBio/goquery v1.5.0
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/biessek/golang-ico v0.0.0-20180326222316-d348d9ea4670
-	github.com/c-bata/go-prompt v0.2.2 // indirect
 	github.com/dustin/go-humanize v0.0.0-20180713052910-9f541cc9db5d
 	github.com/ghetzel/cli v1.17.0
 	github.com/ghetzel/go-stockutil v1.8.17
@@ -24,7 +23,6 @@ require (
 	github.com/microcosm-cc/bluemonday v1.0.0
 	github.com/montanaflynn/stats v0.0.0-20151014174947-eeaced052adb
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
-	github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1
 	github.com/signalsciences/tlstext v1.2.0
 	github.com/spaolacci/murmur3 v0.0.0-20170819071325-9f5d223c6079

--- a/postprocessors.go
+++ b/postprocessors.go
@@ -1,6 +1,7 @@
 package diecast
 
 import (
+	"net/http"
 	"regexp"
 
 	"github.com/yosssi/gohtml"
@@ -8,7 +9,7 @@ import (
 
 var rxEmptyLine = regexp.MustCompile(`(?m)^\s*$[\r\n]*|[\r\n]+\s+\z`)
 
-type PostprocessorFunc func(string) (string, error)
+type PostprocessorFunc func(string, *http.Request) (string, error)
 
 func init() {
 	RegisterPostprocessor(`trim-empty-lines`, TrimEmptyLines)
@@ -23,10 +24,10 @@ func RegisterPostprocessor(name string, ppfunc PostprocessorFunc) {
 	}
 }
 
-func TrimEmptyLines(in string) (string, error) {
+func TrimEmptyLines(in string, req *http.Request) (string, error) {
 	return rxEmptyLine.ReplaceAllString(in, ``) + "\n", nil
 }
 
-func PrettifyHTML(in string) (string, error) {
+func PrettifyHTML(in string, req *http.Request) (string, error) {
 	return gohtml.Format(in), nil
 }

--- a/renderers_template.go
+++ b/renderers_template.go
@@ -112,9 +112,9 @@ func (self *TemplateRenderer) Render(w http.ResponseWriter, req *http.Request, o
 			w.Header().Set(`Content-Type`, options.MimeType)
 
 			if options.Fragments.HasLayout() {
-				return tmpl.Render(w, options.Data, LayoutTemplateName)
+				return tmpl.renderWithRequest(req, w, options.Data, LayoutTemplateName)
 			} else {
-				return tmpl.Render(w, options.Data, ``)
+				return tmpl.renderWithRequest(req, w, options.Data, ``)
 			}
 		}
 	} else if self.server.ShouldReturnSource(req) {

--- a/server.go
+++ b/server.go
@@ -186,21 +186,22 @@ func (self *CSRF) IsExempt(req *http.Request) bool {
 }
 
 type Server struct {
-	Actions             []*Action                 `yaml:"actions"                 json:"actions"`            // Configure routes and actions to execute when those routes are requested.
-	AdditionalFunctions template.FuncMap          `yaml:"-"                       json:"-"`                  // Allow for the programmatic addition of extra functions for use in templates.
-	Address             string                    `yaml:"address"                 json:"address"`            // The host:port address the server is listening on
-	Authenticators      AuthenticatorConfigs      `yaml:"authenticators"          json:"authenticators"`     // A set of authenticator configurations used to protect some or all routes.
-	Autoindex           bool                      `yaml:"autoindex"               json:"autoindex"`          // Specify that requests that terminate at a filesystem directory should automatically generate an index listing of that directory.
-	AutoindexTemplate   string                    `yaml:"autoindexTemplate"       json:"autoindexTemplate"`  // If Autoindex is enabled, this allows the template used to generate the index page to be customized.
-	AutolayoutPatterns  []string                  `yaml:"autolayoutPatterns"      json:"autolayoutPatterns"` // Which types of files will automatically have layouts applied.
-	BaseHeader          *TemplateHeader           `yaml:"header"                  json:"header"`             // A default header that all templates will inherit from.
-	BinPath             string                    `yaml:"-"                       json:"-"`                  // Exposes the location of the diecast binary
-	BindingPrefix       string                    `yaml:"bindingPrefix"           json:"bindingPrefix"`      // Specify a string to prefix all binding resource values that start with "/"
-	Bindings            []Binding                 `yaml:"bindings"                json:"bindings"`           // Top-level bindings that apply to every rendered template
-	DefaultPageObject   map[string]interface{}    `yaml:"-"                       json:"-"`
+	Actions             []*Action                 `yaml:"actions"                 json:"actions"`                 // Configure routes and actions to execute when those routes are requested.
+	AdditionalFunctions template.FuncMap          `yaml:"-"                       json:"-"`                       // Allow for the programmatic addition of extra functions for use in templates.
+	Address             string                    `yaml:"address"                 json:"address"`                 // The host:port address the server is listening on
+	Authenticators      AuthenticatorConfigs      `yaml:"authenticators"          json:"authenticators"`          // A set of authenticator configurations used to protect some or all routes.
+	Autoindex           bool                      `yaml:"autoindex"               json:"autoindex"`               // Specify that requests that terminate at a filesystem directory should automatically generate an index listing of that directory.
+	AutoindexTemplate   string                    `yaml:"autoindexTemplate"       json:"autoindexTemplate"`       // If Autoindex is enabled, this allows the template used to generate the index page to be customized.
+	AutolayoutPatterns  []string                  `yaml:"autolayoutPatterns"      json:"autolayoutPatterns"`      // Which types of files will automatically have layouts applied.
+	BaseHeader          *TemplateHeader           `yaml:"header"                  json:"header"`                  // A default header that all templates will inherit from.
+	BinPath             string                    `yaml:"-"                       json:"-"`                       // Exposes the location of the diecast binary
+	BindingPrefix       string                    `yaml:"bindingPrefix"           json:"bindingPrefix"`           // Specify a string to prefix all binding resource values that start with "/"
+	Bindings            []Binding                 `yaml:"bindings"                json:"bindings"`                // Top-level bindings that apply to every rendered template
+	DefaultPageObject   map[string]interface{}    `yaml:"-"                       json:"-"`                       //
 	DisableCommands     bool                      `yaml:"disable_commands"        json:"disable_commands"`        // Disable the execution of PrestartCommands and StartCommand .
 	DisableTimings      bool                      `yaml:"disableTimings"          json:"disableTimings"`          // Disable emitting per-request Server-Timing headers to aid in tracing bottlenecks and performance issues.
 	EnableDebugging     bool                      `yaml:"debug"                   json:"debug"`                   // Enables additional options for debugging applications. Caution: can expose secrets and other sensitive data.
+	DebugDumpRequests   map[string]string         `yaml:"debugDumpRequests"       json:"debugDumpRequests"`       // An object keyed on path globs whose values are a directory where matching requests are dumped in their entirety as text files.
 	EnableLayouts       bool                      `yaml:"enableLayouts"           json:"enableLayouts"`           // Specifies whether layouts are enabled
 	Environment         string                    `yaml:"environment"             json:"environment"`             // Specify the environment for loading environment-specific configuration files in the form "diecast.env.yml"
 	ErrorsPath          string                    `yaml:"errors"                  json:"errors"`                  // The path to the errors template directory
@@ -214,22 +215,22 @@ type Server struct {
 	MountConfigs        []MountConfig             `yaml:"mounts"                  json:"mounts"`                  // A list of mount configurations read from the diecast.yml config file.
 	Mounts              []Mount                   `yaml:"-"                       json:"-"`                       // The set of all registered mounts.
 	OnAddHandler        AddHandlerFunc            `yaml:"-"                       json:"-"`                       // A function that can be used to intercept handlers being added to the server.
-	OverridePageObject  map[string]interface{}    `yaml:"-"                       json:"-"`
-	PrestartCommands    []*StartCommand           `yaml:"prestart"                json:"prestart"`               // A command that will be executed before the server is started.
-	Protocols           map[string]ProtocolConfig `yaml:"protocols"               json:"protocols"`              // Setup global configuration details for Binding Protocols
-	RendererMappings    map[string]string         `yaml:"rendererMapping"         json:"rendererMapping"`        // Map file extensions to preferred renderers for a given file type.
-	RootPath            string                    `yaml:"root"                    json:"root"`                   // The filesystem location where templates and files are served from
-	RoutePrefix         string                    `yaml:"routePrefix"             json:"routePrefix"`            // If specified, all requests must be prefixed with this string.
-	StartCommands       []*StartCommand           `yaml:"start"                   json:"start"`                  // A command that will be executed after the server is confirmed running.
-	TLS                 *TlsConfig                `yaml:"tls"                     json:"tls"`                    // where SSL/TLS configuration is stored
-	TemplatePatterns    []string                  `yaml:"patterns"                json:"patterns"`               // A set of glob patterns specifying which files will be rendered as templates.
-	Translations        map[string]interface{}    `yaml:"translations,omitempty"  json:"translations,omitempty"` // Stores translations for use with the i18n and l10n functions.  Keys values represent the
-	TrustedRootPEMs     []string                  `yaml:"trustedRootPEMs"         json:"trustedRootPEMs"`        // List of filenames containing PEM-encoded X.509 TLS certificates that represent trusted authorities.  Use to validate certificates signed by an internal, non-public authority.
-	TryExtensions       []string                  `yaml:"tryExtensions"           json:"tryExtensions"`          // Try these file extensions when looking for default (i.e.: "index") files.  If IndexFile has an extension, it will be stripped first.
-	TryLocalFirst       bool                      `yaml:"localFirst"              json:"localFirst"`             // Whether to attempt to locate a local file matching the requested path before attempting to find a template.
-	VerifyFile          string                    `yaml:"verifyFile"              json:"verifyFile"`             // A file that must exist and be readable before starting the server.
-	PreserveConnections bool                      `yaml:"preserveConnections"     json:"preserveConnections"`    // Don't add the "Connection: close" header to every response.
-	CSRF                *CSRF                     `yaml:"csrf"                    json:"csrf"`                   // configures CSRF protection
+	OverridePageObject  map[string]interface{}    `yaml:"-"                       json:"-"`                       //
+	PrestartCommands    []*StartCommand           `yaml:"prestart"                json:"prestart"`                // A command that will be executed before the server is started.
+	Protocols           map[string]ProtocolConfig `yaml:"protocols"               json:"protocols"`               // Setup global configuration details for Binding Protocols
+	RendererMappings    map[string]string         `yaml:"rendererMapping"         json:"rendererMapping"`         // Map file extensions to preferred renderers for a given file type.
+	RootPath            string                    `yaml:"root"                    json:"root"`                    // The filesystem location where templates and files are served from
+	RoutePrefix         string                    `yaml:"routePrefix"             json:"routePrefix"`             // If specified, all requests must be prefixed with this string.
+	StartCommands       []*StartCommand           `yaml:"start"                   json:"start"`                   // A command that will be executed after the server is confirmed running.
+	TLS                 *TlsConfig                `yaml:"tls"                     json:"tls"`                     // where SSL/TLS configuration is stored
+	TemplatePatterns    []string                  `yaml:"patterns"                json:"patterns"`                // A set of glob patterns specifying which files will be rendered as templates.
+	Translations        map[string]interface{}    `yaml:"translations,omitempty"  json:"translations,omitempty"`  // Stores translations for use with the i18n and l10n functions.  Keys values represent the
+	TrustedRootPEMs     []string                  `yaml:"trustedRootPEMs"         json:"trustedRootPEMs"`         // List of filenames containing PEM-encoded X.509 TLS certificates that represent trusted authorities.  Use to validate certificates signed by an internal, non-public authority.
+	TryExtensions       []string                  `yaml:"tryExtensions"           json:"tryExtensions"`           // Try these file extensions when looking for default (i.e.: "index") files.  If IndexFile has an extension, it will be stripped first.
+	TryLocalFirst       bool                      `yaml:"localFirst"              json:"localFirst"`              // Whether to attempt to locate a local file matching the requested path before attempting to find a template.
+	VerifyFile          string                    `yaml:"verifyFile"              json:"verifyFile"`              // A file that must exist and be readable before starting the server.
+	PreserveConnections bool                      `yaml:"preserveConnections"     json:"preserveConnections"`     // Don't add the "Connection: close" header to every response.
+	CSRF                *CSRF                     `yaml:"csrf"                    json:"csrf"`                    // configures CSRF protection
 	altRootCaPool       *x509.CertPool
 	faviconImageIco     []byte
 	fs                  http.FileSystem
@@ -1667,6 +1668,25 @@ func (self *Server) setupServer() error {
 		startRequestTimer(req)
 	})
 
+	// handle request dumper
+	self.handler.UseFunc(func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
+		defer next(w, req)
+
+		for match, destdir := range self.DebugDumpRequests {
+			if fileutil.DirExists(destdir) {
+				if ok, err := filepath.Match(match, req.URL.Path); err == nil && ok || match == `*` {
+					if dump, err := os.Create(filepath.Join(destdir, `diecast-req-`+reqid(req)+`.log`)); err == nil {
+						dump.Write([]byte(formatRequest(req)))
+						dump.Close()
+						log.Debugf("wrote request to %v", dump.Name())
+					} else {
+						log.Warningf("failed to dump request: %v", err)
+					}
+				}
+			}
+		}
+	})
+
 	// inject global headers
 	self.handler.UseFunc(func(w http.ResponseWriter, req *http.Request, next http.HandlerFunc) {
 		defer next(w, req)
@@ -1865,6 +1885,9 @@ func (self *Server) setupServer() error {
 				}
 
 				RegisterPostprocessor(`__diecast_csrf`, func(in string, req *http.Request) (string, error) {
+					start := time.Now()
+					defer reqtime(req, `csrf-inject`, time.Since(start))
+
 					if doc, err := htmldoc(in); err == nil {
 						doc.Find(csrf.InjectFormFieldSelector).AppendHtml(
 							fmt.Sprintf(csrf.FormTokenTagFormat, nosurf.Token(req)),

--- a/template.go
+++ b/template.go
@@ -6,6 +6,7 @@ import (
 	html "html/template"
 	"io"
 	"io/ioutil"
+	"net/http"
 	"path"
 	"strings"
 	text "text/template"
@@ -255,6 +256,10 @@ func (self *Template) prepareError(err error) error {
 }
 
 func (self *Template) Render(w io.Writer, data interface{}, subtemplate string) error {
+	return self.renderWithRequest(nil, w, data, subtemplate)
+}
+
+func (self *Template) renderWithRequest(req *http.Request, w io.Writer, data interface{}, subtemplate string) error {
 	if self.tmpl == nil {
 		return fmt.Errorf("No template input provided")
 	}
@@ -297,7 +302,7 @@ func (self *Template) Render(w io.Writer, data interface{}, subtemplate string) 
 		outstr := output.String()
 
 		for n, postprocessor := range self.postprocessors {
-			if out, err := postprocessor(outstr); err == nil {
+			if out, err := postprocessor(outstr, req); err == nil {
 				outstr = out
 			} else {
 				return self.prepareError(

--- a/util.go
+++ b/util.go
@@ -4,47 +4,11 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/xml"
-	"io"
 	"net/http"
 	"strings"
 
-	"github.com/ghetzel/go-stockutil/log"
 	"github.com/ghetzel/go-stockutil/typeutil"
 )
-
-type multiReadCloser struct {
-	reader  io.Reader
-	closers []io.Closer
-}
-
-func MultiReadCloser(readers ...io.Reader) *multiReadCloser {
-	closers := make([]io.Closer, 0)
-
-	for _, r := range readers {
-		if closer, ok := r.(io.Closer); ok {
-			closers = append(closers, closer)
-		}
-	}
-
-	return &multiReadCloser{
-		reader:  io.MultiReader(readers...),
-		closers: closers,
-	}
-}
-
-func (self *multiReadCloser) Read(p []byte) (int, error) {
-	return self.reader.Read(p)
-}
-
-func (self *multiReadCloser) Close() error {
-	var mErr error
-
-	for _, closer := range self.closers {
-		mErr = log.AppendError(mErr, closer.Close())
-	}
-
-	return mErr
-}
 
 type xmlNode struct {
 	XMLName  xml.Name

--- a/version.go
+++ b/version.go
@@ -2,4 +2,5 @@ package diecast
 
 const ApplicationName = `diecast`
 const ApplicationSummary = `a standalone site templating engine that consumes REST services and renders static HTML output in realtime`
-const ApplicationVersion = `1.15.20`
+const ApplicationVersion = `1.15.21`
+const DiecastUserAgentString = `diecast/` + ApplicationVersion

--- a/version.go
+++ b/version.go
@@ -2,4 +2,4 @@ package diecast
 
 const ApplicationName = `diecast`
 const ApplicationSummary = `a standalone site templating engine that consumes REST services and renders static HTML output in realtime`
-const ApplicationVersion = `1.15.19`
+const ApplicationVersion = `1.15.20`


### PR DESCRIPTION
Two primary changes implemented here:

1. If enabled (via `csrf.injectFormFields`), responses will be scanned for HTML content before being sent to the client, and if given CSS selector matches, a new `<input>` tag will be injected into the content that includes that request's CSRF token.  This allows for transparent serving of CSRF-protected forms without actually modifying any templates or upstream code.

2. Allow proxy mounts to specify the maximum amount of data that will be buffered in Diecast's memory before switching to `Transfer-Encoding: chunked`.  This is primarily for the benefit of WSGI-backed services (e.g.: Django) that don't support chunked transfers.  This is apparently a limitation of the WSGI protocol itself (https://www.python.org/dev/peps/pep-3333/#handling-the-content-length-header, https://stackoverflow.com/questions/12091067/handling-http-chunked-encoding-with-django/12091479#12091479)
