### PR TITLE
Adding request authenticator, cleaning up how error statuses are returned

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -111,6 +111,8 @@ func returnAuthenticatorFor(auth *AuthenticatorConfig) (Authenticator, error) {
 		authenticator, err = NewOauthAuthenticator(auth)
 	case `shell`:
 		authenticator, err = NewShellAuthenticator(auth)
+	case `request`:
+		authenticator, err = NewRequestAuthenticator(auth)
 	case `always`:
 		authenticator, err = NewStaticAuthenticator(auth, true)
 	case `never`:

--- a/authenticator_request.go
+++ b/authenticator_request.go
@@ -1,0 +1,115 @@
+package diecast
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/ghetzel/go-stockutil/httputil"
+	"github.com/ghetzel/go-stockutil/log"
+	"github.com/ghetzel/go-stockutil/sliceutil"
+	"github.com/ghetzel/go-stockutil/stringutil"
+	"github.com/ghetzel/go-stockutil/typeutil"
+)
+
+type RequestAuthenticator struct {
+	config     *AuthenticatorConfig
+	remotes    []string
+	methods    []string
+	headers    map[string]string
+	remoteNets map[string]*net.IPNet
+}
+
+func NewRequestAuthenticator(config *AuthenticatorConfig) (*RequestAuthenticator, error) {
+	auth := &RequestAuthenticator{
+		config: config,
+		methods: sliceutil.MapString(config.O(`methods`).Strings(), func(i int, value string) string {
+			return strings.ToUpper(value)
+		}),
+		remotes:    config.O(`remotes`).Strings(),
+		headers:    make(map[string]string),
+		remoteNets: make(map[string]*net.IPNet),
+	}
+
+	for hdr, pattern := range config.O(`headers`).MapNative() {
+		auth.headers[hdr] = typeutil.String(pattern)
+	}
+
+	for _, remote := range auth.remotes {
+		if strings.Contains(remote, `/`) {
+			if _, ipnet, err := net.ParseCIDR(remote); err == nil {
+				auth.remoteNets[remote] = ipnet
+			} else {
+				return nil, fmt.Errorf("bad remote %q: %v", remote, err)
+			}
+		}
+	}
+
+	return auth, nil
+}
+
+func (self *RequestAuthenticator) Name() string {
+	if self.config != nil && self.config.Name != `` {
+		return self.config.Name
+	} else {
+		return `RequestAuthenticator`
+	}
+}
+
+func (self *RequestAuthenticator) IsCallback(_ *url.URL) bool {
+	return false
+}
+
+func (self *RequestAuthenticator) Callback(w http.ResponseWriter, req *http.Request) {
+
+}
+
+func (self *RequestAuthenticator) Authenticate(w http.ResponseWriter, req *http.Request) bool {
+	if len(self.methods) > 0 {
+		if !sliceutil.ContainsString(self.methods, req.Method) {
+			httputil.RequestSetValue(req, ContextErrorKey, fmt.Sprintf("HTTP method %s is not permitted", req.Method))
+			return false
+		}
+	}
+
+	// if remotes are specified, one must match
+	if len(self.remotes) > 0 {
+		if addr, _ := stringutil.SplitPair(req.RemoteAddr, `:`); addr != `` {
+			for i, remote := range self.remotes {
+				if addr == remote {
+					log.Debugf(
+						"[%s] request-auth: permitting address %v (in remote %d; exact match: %v)",
+						reqid(req),
+						addr,
+						i,
+						remote,
+					)
+					return true
+				} else if ipnet, ok := self.remoteNets[remote]; ok && ipnet != nil {
+					if ip := net.ParseIP(addr); ip != nil {
+						if ipnet.Contains(ip) {
+							log.Debugf(
+								"[%s] request-auth: permitting address %v (in remote %d; network: %v)",
+								reqid(req),
+								addr,
+								i,
+								ipnet,
+							)
+							return true
+						}
+					}
+				}
+			}
+
+			httputil.RequestSetValue(req, ContextErrorKey, fmt.Sprintf("Address %s is not permitted", addr))
+			return false
+		} else {
+			httputil.RequestSetValue(req, ContextErrorKey, "Address could not be determined")
+			return false
+		}
+	}
+
+	return true
+}

--- a/binding.go
+++ b/binding.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/ghetzel/go-stockutil/httputil"
 	"github.com/ghetzel/go-stockutil/log"
 	"github.com/ghetzel/go-stockutil/sliceutil"
 	"github.com/ghetzel/go-stockutil/stringutil"
@@ -127,6 +128,7 @@ func (self *Binding) Evaluate(req *http.Request, header *TemplateHeader, data ma
 	log.Debugf("[%s] Evaluating binding %q", id, self.Name)
 
 	if req.Header.Get(`X-Diecast-Binding`) == self.Name {
+		httputil.RequestSetValue(req, ContextStatusKey, http.StatusLoopDetected)
 		return nil, fmt.Errorf("Loop detected")
 	}
 
@@ -288,6 +290,7 @@ func (self *Binding) Evaluate(req *http.Request, header *TemplateHeader, data ma
 					} else if log.ErrHasPrefix(err, `[`) {
 						return nil, err
 					} else {
+						httputil.RequestSetValue(req, ContextStatusKey, response.StatusCode)
 						return nil, fmt.Errorf("[%s] %s %v: %v", id, method, reqUrl, err)
 					}
 				}

--- a/server_csrf.go
+++ b/server_csrf.go
@@ -23,6 +23,8 @@ const DefaultCsrfInjectFormFieldSelector = `form[method="post"], form[method="PO
 const DefaultCsrfInjectFieldFormat = `<input type="hidden" name="%s" value="%s">`
 const CsrfTokenLength = 32
 const ContextCsrfToken = `csrf-token`
+const ContextStatusKey = `response-status-code`
+const ContextErrorKey = `response-error-message`
 
 var DefaultCsrfHeaderName = `X-CSRF-Token`
 var DefaultCsrfFormFieldName = `csrf_token`

--- a/server_middlewares.go
+++ b/server_middlewares.go
@@ -127,6 +127,7 @@ func (self *Server) middlewareProcessAuthenticators(w http.ResponseWriter, req *
 				auth.Callback(w, req)
 				return false
 			} else if !auth.Authenticate(w, req) {
+				httputil.RequestSetValue(req, ContextStatusKey, http.StatusForbidden)
 				return false
 			}
 		}

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package diecast
 
 const ApplicationName = `diecast`
 const ApplicationSummary = `a standalone site templating engine that consumes REST services and renders static HTML output in realtime`
-const ApplicationVersion = `1.17.0`
+const ApplicationVersion = `1.17.1`
 const DiecastUserAgentString = `diecast/` + ApplicationVersion


### PR DESCRIPTION
- Add a new Authenticator ("request") that allows for resources to be guarded based on request details (remote address, headers, HTTP methods, etc.)
- Add new fields to error pages to access error status and a platform-generated message.
- Fix which status code error page comes up for failed bindings.